### PR TITLE
Add native macOS support (App Bundle, Retina fix, Instructions) & Pythhon script update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ scripts/*
 scripts/binaries
 .dir-locals.el
 embedded.*
+.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,14 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+if(APPLE)
+    set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15")
+    add_definitions(-DMA_NO_RUNTIME_LINKING)
+    set(CMAKE_MACOSX_RPATH 1)
+    set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+    set(CMAKE_INSTALL_RPATH "@executable_path/../Frameworks" "/opt/homebrew/lib" "/usr/local/lib")
+endif()
+
 set(SOURCES
    src/main.c
    src/engine.c
@@ -33,7 +41,28 @@ set(SOURCES
    src/movie.c
 )
 
-add_executable(${PROJECT_NAME} ${SOURCES})
+if(APPLE)
+    set(ICON_PNG "${PROJECT_SOURCE_DIR}/res/window_icon.png")
+    set(ICON_ICNS "${CMAKE_BINARY_DIR}/generated_app_icon.icns")
+
+    add_custom_command(
+        OUTPUT "${ICON_ICNS}"
+        COMMAND sips -s format icns "${ICON_PNG}" --out "${ICON_ICNS}" > /dev/null
+        DEPENDS "${ICON_PNG}"
+        VERBATIM
+    )
+
+    set_source_files_properties("${ICON_ICNS}" PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
+    add_executable(${PROJECT_NAME} MACOSX_BUNDLE ${SOURCES} "${ICON_ICNS}")
+
+    set_target_properties(${PROJECT_NAME} PROPERTIES
+        MACOSX_BUNDLE_BUNDLE_NAME "Lain Bootleg"
+        MACOSX_BUNDLE_GUI_IDENTIFIER "com.lain.bootleg"
+        MACOSX_BUNDLE_ICON_FILE "generated_app_icon.icns"
+    )
+else()
+    add_executable(${PROJECT_NAME} ${SOURCES})
+endif()
 
 if(MSVC)
    target_compile_options(${PROJECT_NAME} PRIVATE /W4)
@@ -43,11 +72,24 @@ endif()
 
 target_include_directories(${PROJECT_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src)
 
-add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-                   COMMAND ${CMAKE_COMMAND} -E copy_directory
-                       ${CMAKE_SOURCE_DIR}/res $<TARGET_FILE_DIR:${PROJECT_NAME}>/res)
+if(APPLE)
+    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+                       COMMAND ${CMAKE_COMMAND} -E copy_directory
+                           ${CMAKE_SOURCE_DIR}/res
+                           ${CMAKE_BINARY_DIR}/${PROJECT_NAME}.app/Contents/Resources/res)
+else()
+    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+                       COMMAND ${CMAKE_COMMAND} -E copy_directory
+                           ${CMAKE_SOURCE_DIR}/res $<TARGET_FILE_DIR:${PROJECT_NAME}>/res)
+endif()
 
-option(SYSTEM_GLEW "Use system-installed GLEW instead of vendored one" OFF)
+if(APPLE)
+    option(SYSTEM_GLFW "Use system-installed GLEW instead of vendored one" ON)
+    option(SYSTEM_GLEW "Use system-installed GLEW instead of vendored one" ON)
+else()
+    option(SYSTEM_GLFW "Use system-installed GLEW instead of vendored one" OFF)
+    option(SYSTEM_GLEW "Use system-installed GLEW instead of vendored one" OFF)
+endif()
 
 if(SYSTEM_GLEW)
    find_package(OpenGL REQUIRED)
@@ -86,6 +128,15 @@ else()
    set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
    add_subdirectory(${CMAKE_SOURCE_DIR}/external/glfw EXCLUDE_FROM_ALL)
    target_link_libraries(${PROJECT_NAME} PRIVATE glfw)
+endif()
+
+# Linking macOS Frameworks
+if(APPLE)
+    target_link_libraries(${PROJECT_NAME} PRIVATE
+        "-framework OpenGL" "-framework Cocoa" "-framework IOKit"
+        "-framework CoreVideo" "-framework CoreAudio" "-framework AudioToolbox"
+        "-framework AudioUnit" "-framework CoreFoundation"
+    )
 endif()
 
 if (UNIX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,11 +8,8 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 if(APPLE)
-    set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15")
+    set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
     add_definitions(-DMA_NO_RUNTIME_LINKING)
-    set(CMAKE_MACOSX_RPATH 1)
-    set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
-    set(CMAKE_INSTALL_RPATH "@executable_path/../Frameworks" "/opt/homebrew/lib" "/usr/local/lib")
 endif()
 
 set(SOURCES
@@ -60,6 +57,11 @@ if(APPLE)
         MACOSX_BUNDLE_GUI_IDENTIFIER "com.lain.bootleg"
         MACOSX_BUNDLE_ICON_FILE "generated_app_icon.icns"
     )
+
+    add_custom_target(bundle
+        COMMAND bash "${PROJECT_SOURCE_DIR}/scripts/bundle.sh" "${CMAKE_BINARY_DIR}" "${PROJECT_NAME}"
+        DEPENDS ${PROJECT_NAME}
+    )
 else()
     add_executable(${PROJECT_NAME} ${SOURCES})
 endif()
@@ -76,20 +78,15 @@ if(APPLE)
     add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
                        COMMAND ${CMAKE_COMMAND} -E copy_directory
                            ${CMAKE_SOURCE_DIR}/res
-                           ${CMAKE_BINARY_DIR}/${PROJECT_NAME}.app/Contents/Resources/res)
+                           ${CMAKE_BINARY_DIR}/${PROJECT_NAME}.app/Contents/Resources/res
+                       COMMENT "Copia risorse (Development build)...")
 else()
     add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
                        COMMAND ${CMAKE_COMMAND} -E copy_directory
                            ${CMAKE_SOURCE_DIR}/res $<TARGET_FILE_DIR:${PROJECT_NAME}>/res)
 endif()
 
-if(APPLE)
-    option(SYSTEM_GLFW "Use system-installed GLEW instead of vendored one" ON)
-    option(SYSTEM_GLEW "Use system-installed GLEW instead of vendored one" ON)
-else()
-    option(SYSTEM_GLFW "Use system-installed GLEW instead of vendored one" OFF)
-    option(SYSTEM_GLEW "Use system-installed GLEW instead of vendored one" OFF)
-endif()
+option(SYSTEM_GLEW "Use system-installed GLEW instead of vendored one" OFF)
 
 if(SYSTEM_GLEW)
    find_package(OpenGL REQUIRED)
@@ -130,7 +127,6 @@ else()
    target_link_libraries(${PROJECT_NAME} PRIVATE glfw)
 endif()
 
-# Linking macOS Frameworks
 if(APPLE)
     target_link_libraries(${PROJECT_NAME} PRIVATE
         "-framework OpenGL" "-framework Cocoa" "-framework IOKit"
@@ -139,7 +135,16 @@ if(APPLE)
     )
 endif()
 
-if (UNIX)
+if(APPLE)
+    set(MPV_INCLUDE_DIRS "/opt/homebrew/include")
+    find_library(MPV_LIBRARY mpv PATHS "/opt/homebrew/lib" "/usr/local/lib" REQUIRED)
+
+    target_include_directories(${PROJECT_NAME} PRIVATE ${MPV_INCLUDE_DIRS})
+    target_link_libraries(${PROJECT_NAME} PRIVATE ${MPV_LIBRARY})
+    
+    set(MPV_LINK_LIBRARIES ${MPV_LIBRARY})
+
+elseif(UNIX)
    find_package(PkgConfig)
    if(PKG_CONFIG_FOUND)
       pkg_check_modules(MPV REQUIRED mpv)
@@ -164,7 +169,7 @@ if (UNIX)
          message(FATAL_ERROR "Unable to find MPV!")
       endif()
    endif()
-endif (UNIX)
+endif()
 
 if (WIN32)
    set(MPV_DIR ${PROJECT_SOURCE_DIR}/external/mpv)

--- a/README.md
+++ b/README.md
@@ -67,16 +67,22 @@ This should produce a binary called `lain-bootleg-bootleg`.
 
 ## Compiling on macOS
 
-Ensure you have **Xcode Command Line Tools** installed (run `xcode-select --install`) and I highly suggest to install and use [**Homebrew**](https://brew.sh/) as you can easily install all dependencies with `brew install cmake glfw glew pkg-config mpv`.
+Ensure you have **Xcode Command Line Tools** installed (run `xcode-select --install`).
+
+You will need [**Homebrew**](https://brew.sh/) to install dependencies.
+Note that `dylibbundler` is required if you want to create a standalone `.app` that works on other Macs.
+`brew install cmake glfw glew pkg-config mpv dylibbundlerbrew`.
+
 
 To build:
 
 1. `cd` into the repo
 2. `mkdir build && cd build`
 3. `cmake ..`
-4. `make`
 
-This produces a macOS App Bundle named `lain-bootleg-bootleg`.
+From here, you now have two options:
+- `make`: This produces a .app that links dynamically to your local Homebrew libraries.
+- `make bundle`: This runs a script that collects all dependencies, fixes paths for portability, handles Python framework linking, and signs the app.
 
 ## Compiling on Windows using MinGW and MSYS2
 
@@ -104,8 +110,13 @@ This should produce an executable called `lain-bootleg-bootleg.exe`.
 
 # Editing the save file
 
-Upon closing the game for the first time, you will notice a new file in the same directory
-as the executable called `lain_save.json`, which will have a format similar to:
+Upon closing the game for the first time, a save file named `lain_save.json` will be created.
+
+**Location:**
+* **Windows / Linux:** In the same directory as the executable.
+* **macOS:** Inside the App Bundle. Right-click `lain-bootleg-bootleg.app` -> **Show Package Contents**, then navigate to `Contents/Resources/lain_save.json`.
+
+The file format looks like this:
 
 ```
 {

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ This project aims to reverse-engineer and remake Lain Bootleg, a Serial Experime
 
 To run the Python scripts you are going to need [`opencv-python`](https://pypi.org/project/opencv-python/) and [`pefile`](https://pypi.org/project/pefile/).
 
+**Note for macOS users:** You will need also [`pillow`](https://pypi.org/project/pillow/) and `setuptools`. On recent systems preventing global pip installation use a virtual environment with this: 
+
+```sh
+python3 -m venv venv
+source venv/bin/activate
+pip install opencv-python pefile Pillow setuptools
+```
+
 The repository doesn't contain the game's assets, the extraction is done by automation scripts
 located under the `scripts/` directory.
 
@@ -56,6 +64,19 @@ cmake -DSYSTEM_GLFW=ON -DSYSTEM_GLEW=ON ..
 4. `make`
 
 This should produce a binary called `lain-bootleg-bootleg`.
+
+## Compiling on macOS
+
+Ensure you have **Xcode Command Line Tools** installed (run `xcode-select --install`) and I highly suggest to install and use [**Homebrew**](https://brew.sh/) as you can easily install all dependencies with `brew install cmake glfw glew pkg-config mpv`.
+
+To build:
+
+1. `cd` into the repo
+2. `mkdir build && cd build`
+3. `cmake ..`
+4. `make`
+
+This produces a macOS App Bundle named `lain-bootleg-bootleg`.
 
 ## Compiling on Windows using MinGW and MSYS2
 

--- a/README.md
+++ b/README.md
@@ -70,8 +70,9 @@ This should produce a binary called `lain-bootleg-bootleg`.
 Ensure you have **Xcode Command Line Tools** installed (run `xcode-select --install`).
 
 You will need [**Homebrew**](https://brew.sh/) to install dependencies.
-Note that `dylibbundler` is required if you want to create a standalone `.app` that works on other Macs.
-`brew install cmake glfw glew pkg-config mpv dylibbundlerbrew`.
+Note that [dylibbundler](https://github.com/auriamg/macdylibbundler) is only required if you want to create a standalone `.app`.
+
+`brew install cmake mpv dylibbundler`.
 
 
 To build:

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# Usage: ./scripts/bundle.sh <build_dir> <project_name>
+
+BUILD_DIR="$1"
+PROJECT_NAME="$2"
+APP_BUNDLE="$BUILD_DIR/$PROJECT_NAME.app"
+FRAMEWORKS_DIR="$APP_BUNDLE/Contents/Frameworks"
+MACOS_DIR="$APP_BUNDLE/Contents/MacOS"
+EXE_PATH="$MACOS_DIR/$PROJECT_NAME"
+
+# Detect architecture to set Homebrew prefix
+ARCH=$(uname -m)
+if [ "$ARCH" == "arm64" ]; then
+    HB_PREFIX="/opt/homebrew"
+else
+    HB_PREFIX="/usr/local"
+fi
+
+echo "Bundling $PROJECT_NAME for $ARCH..."
+
+# Run dylibbundler to collect standard dependencies
+mkdir -p "$FRAMEWORKS_DIR"
+dylibbundler -of -cd -b -x "$EXE_PATH" -d "$FRAMEWORKS_DIR" -p "@executable_path/../Frameworks/" > /dev/null 2>&1 || true
+
+# Manual Python Framework handling
+if [ ! -f "$FRAMEWORKS_DIR/Python" ]; then
+    PY_SRC=$(find "$HB_PREFIX" -name Python 2>/dev/null | grep "Python.framework/Versions/3.*/Python$" | grep -v "Resources/Python.app" | sort -r | head -n 1)
+
+    if [ -n "$PY_SRC" ]; then
+        FILE_TYPE=$(file "$PY_SRC")
+        if [[ "$FILE_TYPE" == *"executable"* ]] && [[ "$FILE_TYPE" != *"dynamically linked shared library"* ]]; then
+             PY_SRC=$(find "$(dirname "$PY_SRC")/../.." -name "libpython3.*.dylib" | head -n 1)
+        fi
+    fi
+
+    if [ -n "$PY_SRC" ]; then
+        cp "$PY_SRC" "$FRAMEWORKS_DIR/Python"
+        chmod +w "$FRAMEWORKS_DIR/Python"
+        install_name_tool -id "@loader_path/Python" "$FRAMEWORKS_DIR/Python"
+    fi
+fi
+
+# Clean up library paths in Frameworks
+find "$FRAMEWORKS_DIR" -type f | while read LIB; do
+    [ -f "$LIB" ] || continue
+    chmod +w "$LIB"
+    LIB_NAME=$(basename "$LIB")
+
+    # Remove duplicate RPATHs if present
+    install_name_tool -delete_rpath "@executable_path/../Frameworks/" "$LIB" 2>/dev/null
+    install_name_tool -id "@loader_path/$LIB_NAME" "$LIB" 2>/dev/null
+
+    # Relink Homebrew dependencies to @loader_path
+    otool -L "$LIB" | grep -E "$HB_PREFIX|Python.framework" | awk '{print $1}' | while read DEP; do
+        DEP_NAME=$(basename "$DEP")
+        if [[ "$DEP" == *"Python"* ]]; then
+            install_name_tool -change "$DEP" "@loader_path/Python" "$LIB"
+        else
+            install_name_tool -change "$DEP" "@loader_path/$DEP_NAME" "$LIB"
+        fi
+    done
+done
+
+# Fix main executable paths
+install_name_tool -add_rpath "@executable_path/../Frameworks/" "$EXE_PATH" 2>/dev/null
+
+otool -L "$EXE_PATH" | grep -E "$HB_PREFIX|Python.framework" | awk '{print $1}' | while read DEP; do
+    DEP_NAME=$(basename "$DEP")
+    if [[ "$DEP" == *"Python"* ]]; then
+        install_name_tool -change "$DEP" "@executable_path/../Frameworks/Python" "$EXE_PATH"
+    else
+        install_name_tool -change "$DEP" "@executable_path/../Frameworks/$DEP_NAME" "$EXE_PATH"
+    fi
+done
+
+# Sign the bundle
+codesign --force --sign - --deep "$APP_BUNDLE"

--- a/src/movie.c
+++ b/src/movie.c
@@ -96,6 +96,10 @@ int movie_init(Movie *movie)
 	}
 
 	mpv_request_log_messages(movie->mpv_handle, "debug");
+	
+	#ifdef __APPLE__
+		mpv_set_option_string(movie->mpv_handle, "vo", "libmpv");
+	#endif
 
 	mpv_render_param params[] = {
 	    {MPV_RENDER_PARAM_API_TYPE, MPV_RENDER_API_TYPE_OPENGL},

--- a/src/window.c
+++ b/src/window.c
@@ -83,6 +83,7 @@ int make_window(GLFWwindow **window, int width, int height, char *name,
 {
 	glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE);
 	glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+	glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_FALSE);
 
 	*window = glfwCreateWindow(width, height, name, NULL, shared_ctx);
 	if (window == NULL) {

--- a/src/window.c
+++ b/src/window.c
@@ -24,11 +24,13 @@ static void set_window_icon(GLFWwindow *window)
 {
 	stbi_set_flip_vertically_on_load(false);
 
+	#ifndef __APPLE__
 	GLFWimage images[1];
 	images[0].pixels = stbi_load("./res/window_icon.png", &images[0].width,
 				     &images[0].height, 0, 4);
 	glfwSetWindowIcon(window, 1, images);
 	stbi_image_free(images[0].pixels);
+	#endif
 }
 
 static GLFWmonitor *get_current_monitor(GLFWwindow *window)

--- a/src/window.c
+++ b/src/window.c
@@ -83,7 +83,10 @@ int make_window(GLFWwindow **window, int width, int height, char *name,
 {
 	glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE);
 	glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+
+	#ifdef __APPLE__
 	glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_FALSE);
+    #endif
 
 	*window = glfwCreateWindow(width, height, name, NULL, shared_ctx);
 	if (window == NULL) {


### PR DESCRIPTION
Hi! As requested in the [website](https://laingame.net/bootleg/), I've implemented full native macOS support and updated some build instructions.

### Changes included:

**Build System (`CMakeLists.txt`):**
- Added logic to build a macOS App Bundle (`.app`).
- It automatically converts `window_icon.png` to `.icns` using `sips`.
- Links required Apple Frameworks (Cocoa, IOKit, etc.).
- **Fix:** On macOS, I've forced the use of system-installed GLEW/GLFW (via Homebrew) instead of the vendored submodules. This avoids a linker error with the deprecated `AGL` framework present in the old submodule configuration.

**Code Adjustments:**
- **`src/movie.c`**: Added `vo=libmpv` option on macOS to prevent MPV from spawning a separate window and crashing on exit.
- **`src/window.c`**: Fixed some resolution problem.

**Documentation & Scripts:**
- **`README.md`**: Added a "Compiling on macOS" section. Updated the "Extracting assets" section to include missing Python dependencies (`Pillow`, `setuptools`) and instructions for `venv` usage (required for PEP 668 compliance on modern systems).

Tested on macOS Sequoia with Homebrew dependencies.